### PR TITLE
feat(cleanup): low effort clean up fixes

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -6,43 +6,10 @@ layout covering an intro, resume, projects, and contact info.
 
 Check it out at [laynebritton.net](https://laynebritton.net).
 
-## Tech stack
-
-- React 18 + TypeScript
-- React Bootstrap / Bootstrap 5 for layout and components
-- Framer Motion for subtle animation
-- Mixpanel for analytics
-- Playwright for end-to-end tests
-
-## Development
-
-```bash
-npm install
-npm start        # run the dev server at http://localhost:3000
-npm run build    # production build to ./build
-npm test         # unit tests (react-scripts / jest)
-npm run test:e2e # Playwright end-to-end tests
-npm run lint     # eslint
-npm run format   # prettier
-```
-
-### Environment
-
-Analytics and environment configuration are read from `.env` (gitignored). See
-`.env.example` for the expected variables:
-
-- `REACT_APP_ENVIRONMENT` — set to `prod` to enable analytics
-- `REACT_APP_MIXPANEL_ANALYTICS_TOKEN` — Mixpanel project token
-
 ## Analytics
+This project utilizes Mixpanel third-party analytics to track data and trends over time. 
 
-This project uses Mixpanel to track key events (page views and outbound link
-clicks) so I can understand how the site is used and what to improve over time.
-Tracking is only initialized when `REACT_APP_ENVIRONMENT` is `prod` and a token
-is present, so local development and tests never emit events.
+I track most important events on the website. I receive a weekly email digest with site analytics. Helps me stay up to date on the site is being used, what flows users commonly engage with, and what can improved, added, or modified from the site.
 
-## Deployment
-
-The site is deployed via the GitHub Actions workflow in
-[.github/workflows](.github/workflows). `npm run build` produces the static
-bundle that is served in production.
+For some visuals, here's a snapshot of my analytics dashboard from the month of August in 2022
+![image](https://user-images.githubusercontent.com/21363865/202249270-6d3429c3-bcb6-4da3-aa72-65c59ef81060.png)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,48 @@
 # laynebritton.net
 
-My home page website. Built from scratch using React Typescript. 
+My personal home page and portfolio. Built from scratch with React + TypeScript
+(Create React App) and React Bootstrap, with a single-page, anchor-navigated
+layout covering an intro, resume, projects, and contact info.
 
-Check it out at [laynebritton.net](https://www.laynebritton.net)
+Check it out at [laynebritton.net](https://laynebritton.net).
 
-### Features
-- Analytics using Mixpanel
-- Custom styling and layouts designed by me
+## Tech stack
+
+- React 18 + TypeScript
+- React Bootstrap / Bootstrap 5 for layout and components
+- Framer Motion for subtle animation
+- Mixpanel for analytics
+- Playwright for end-to-end tests
+
+## Development
+
+```bash
+npm install
+npm start        # run the dev server at http://localhost:3000
+npm run build    # production build to ./build
+npm test         # unit tests (react-scripts / jest)
+npm run test:e2e # Playwright end-to-end tests
+npm run lint     # eslint
+npm run format   # prettier
+```
+
+### Environment
+
+Analytics and environment configuration are read from `.env` (gitignored). See
+`.env.example` for the expected variables:
+
+- `REACT_APP_ENVIRONMENT` — set to `prod` to enable analytics
+- `REACT_APP_MIXPANEL_ANALYTICS_TOKEN` — Mixpanel project token
 
 ## Analytics
-This project utilizes Mixpanel third-party analytics to track data and trends over time. 
 
-I track most important events on the website. I receive a weekly email digest with site analytics. Helps me stay up to date on the site is being used, what flows users commonly engage with, and what can improved, added, or modified from the site.
+This project uses Mixpanel to track key events (page views and outbound link
+clicks) so I can understand how the site is used and what to improve over time.
+Tracking is only initialized when `REACT_APP_ENVIRONMENT` is `prod` and a token
+is present, so local development and tests never emit events.
 
-For some visuals, here's a snapshot of my analytics dashboard from the month of August in 2022
-![image](https://user-images.githubusercontent.com/21363865/202249270-6d3429c3-bcb6-4da3-aa72-65c59ef81060.png)
+## Deployment
+
+The site is deployed via the GitHub Actions workflow in
+[.github/workflows](.github/workflows). `npm run build` produces the static
+bundle that is served in production.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # laynebritton.net
 
-My personal home page and portfolio. Built from scratch with React + TypeScript
-(Create React App) and React Bootstrap, with a single-page, anchor-navigated
-layout covering an intro, resume, projects, and contact info.
+My home page website. Built from scratch using React Typescript. 
 
 Check it out at [laynebritton.net](https://laynebritton.net).
 
 ## Analytics
-This project utilizes Mixpanel third-party analytics to track data and trends over time. 
 
-I track most important events on the website. I receive a weekly email digest with site analytics. Helps me stay up to date on the site is being used, what flows users commonly engage with, and what can improved, added, or modified from the site.
+Every Monday morning I get an email with stats on site engagement over the past week.
 
 For some visuals, here's a snapshot of my analytics dashboard from the month of August in 2022
 ![image](https://user-images.githubusercontent.com/21363865/202249270-6d3429c3-bcb6-4da3-aa72-65c59ef81060.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "react-bootstrap": "^2.10.0",
         "react-bootstrap-icons": "1.10.3",
         "react-dom": "^18.2.0",
-        "react-infinite-scroll-component": "^6.1.0",
         "react-router-dom": "^6.22.0",
         "react-scripts": "5.0.1",
         "sass": "^1.70.0",
@@ -19744,17 +19743,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
-    "node_modules/react-infinite-scroll-component": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
-      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
-      "dependencies": {
-        "throttle-debounce": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -23054,14 +23042,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
       "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==",
       "license": "MIT"
-    },
-    "node_modules/throttle-debounce": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
-      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/thunky": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "layne-britton-net",
   "version": "0.1.0",
-  "homepage": "http://laynebritton.net",
+  "homepage": "https://laynebritton.net",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^6.4.2",
@@ -19,7 +19,6 @@
     "react-bootstrap": "^2.10.0",
     "react-bootstrap-icons": "1.10.3",
     "react-dom": "^18.2.0",
-    "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.22.0",
     "react-scripts": "5.0.1",
     "sass": "^1.70.0",

--- a/public/index.html
+++ b/public/index.html
@@ -7,9 +7,34 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Layne Britton's home page"
+      content="Layne Britton — Software Engineer in Brooklyn, NY. Portfolio, resume, and engineering projects."
     />
-    
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://laynebritton.net" />
+    <meta property="og:title" content="Layne Britton — Software Engineer" />
+    <meta
+      property="og:description"
+      content="Software Engineer in Brooklyn, NY. Portfolio, resume, and engineering projects."
+    />
+    <meta
+      property="og:image"
+      content="https://s3.amazonaws.com/laynebritton.net-media/public/nyc_fidi_from_brooklyn.png"
+    />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Layne Britton — Software Engineer" />
+    <meta
+      name="twitter:description"
+      content="Software Engineer in Brooklyn, NY. Portfolio, resume, and engineering projects."
+    />
+    <meta
+      name="twitter:image"
+      content="https://s3.amazonaws.com/laynebritton.net-media/public/nyc_fidi_from_brooklyn.png"
+    />
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Layne Britton — Software Engineer in Brooklyn, NY. Portfolio, resume, and engineering projects."
+      content="Layne Britton's home page"
     />
 
     <!-- Open Graph -->
@@ -16,7 +16,7 @@
     <meta property="og:title" content="Layne Britton — Software Engineer" />
     <meta
       property="og:description"
-      content="Software Engineer in Brooklyn, NY. Portfolio, resume, and engineering projects."
+      content="Layne Britton's home page"
     />
     <meta
       property="og:image"
@@ -28,7 +28,7 @@
     <meta name="twitter:title" content="Layne Britton — Software Engineer" />
     <meta
       name="twitter:description"
-      content="Software Engineer in Brooklyn, NY. Portfolio, resume, and engineering projects."
+      content="Layne Britton's home page"
     />
     <meta
       name="twitter:image"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Infinite Dogs",
-  "name": "Infinite Dogs",
+  "short_name": "Layne Britton",
+  "name": "Layne Britton — Software Engineer",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import './App.scss';
+import { useEffect } from 'react';
 import Home from './pages/Home/Home';
 import Navigation from './components/Navigation/Navigation';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import * as ROUTES from './util/Routes';
 import { InitializeAnalytics } from './util/Analytics';
+import NotFound from './pages/NotFound/NotFound';
 
 function App() {
-  InitializeAnalytics();
+  useEffect(() => {
+    InitializeAnalytics();
+  }, []);
 
   return (
     <div>
@@ -18,15 +22,7 @@ function App() {
           <Route path={ROUTES.CONTACT} element={<Home />} />
           {/* <Route path={ROUTES.ARCHIVE} element={<Archive />} /> */}
 
-          <Route
-            path="*"
-            element={
-              <a href={ROUTES.HOME}>
-                {' '}
-                Page not found. Click here to go to the home page
-              </a>
-            }
-          />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -30,6 +30,7 @@ export const ProjectCard = ({
             <Card.Img
               variant="top"
               src={media}
+              alt={title}
               style={{
                 objectFit: 'cover',
                 width: '100%',
@@ -46,6 +47,7 @@ export const ProjectCard = ({
               <Button
                 href={projectUrl}
                 target="_blank"
+                rel="noopener noreferrer"
                 style={SitePrimaryButton}
                 onClick={() => {
                   TrackEvent(eventName);
@@ -60,6 +62,7 @@ export const ProjectCard = ({
               <Button
                 href={githubUrl}
                 target="_blank"
+                rel="noopener noreferrer"
                 style={SitePrimaryButton}
                 onClick={() => {
                   TrackEvent(eventName + ' GitHub');

--- a/src/components/ResponsiveContent/ResponsiveContent.tsx
+++ b/src/components/ResponsiveContent/ResponsiveContent.tsx
@@ -24,7 +24,7 @@ export const ResponsiveContent = ({
       return (
         <Container>
           <Row>
-            <Col xs="1" className={'d-xs-block d-sm-none'}></Col>
+            <Col xs="1" className={'d-block d-sm-none'}></Col>
             <Col xs="10" sm="8">
               {children}
             </Col>
@@ -35,7 +35,7 @@ export const ResponsiveContent = ({
     case ResponsiveContentType.ROW:
       return (
         <Row>
-          <Col xs="1" className={'d-xs-block d-sm-none'}></Col>
+          <Col xs="1" className={'d-block d-sm-none'}></Col>
           <Col xs="10" sm="8">
             {children}
           </Col>
@@ -45,7 +45,7 @@ export const ResponsiveContent = ({
     case ResponsiveContentType.COLUMN:
       return (
         <>
-          <Col xs="1" className={'d-xs-block d-sm-none'}></Col>
+          <Col xs="1" className={'d-block d-sm-none'}></Col>
           <Col xs="10" sm="8">
             {children}
           </Col>

--- a/src/pages/Contact/Contact.tsx
+++ b/src/pages/Contact/Contact.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { ResponsiveContent } from '../../components/ResponsiveContent/ResponsiveContent';
 import { TrackEvent } from '../../util/Analytics';
 import * as ANALYTICS_CONSTANTS from '../../util/AnalyticsConstants';
@@ -7,7 +7,9 @@ import { LinkedInLink } from '../Resume/Resume';
 const EmailLink = 'mailto:layne@laynebritton.net';
 
 const Contact: FC = () => {
-  // TrackEvent(ANALYTICS_CONSTANTS.VIEW_CONTACT);
+  useEffect(() => {
+    TrackEvent(ANALYTICS_CONSTANTS.VIEW_CONTACT);
+  }, []);
 
   return (
     <ResponsiveContent>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import Hero from '../../components/Hero/Hero';
 import styles from './Home.module.css';
@@ -10,7 +10,10 @@ import Contact from '../Contact/Contact';
 interface HomeProps {}
 
 const Home: FC<HomeProps> = () => {
-  TrackEvent(ANALYTICS_CONSTANTS.VIEW_HOME_PAGE);
+  useEffect(() => {
+    TrackEvent(ANALYTICS_CONSTANTS.VIEW_HOME_PAGE);
+  }, []);
+
   return (
     <>
       <div

--- a/src/pages/NotFound/NotFound.tsx
+++ b/src/pages/NotFound/NotFound.tsx
@@ -1,0 +1,26 @@
+import { FC } from 'react';
+import { Button } from 'react-bootstrap';
+import { SitePrimaryButton } from '../../theme/theme';
+import * as ROUTES from '../../util/Routes';
+
+const NotFound: FC = () => (
+  <div
+    style={{
+      minHeight: '70vh',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      textAlign: 'center',
+      padding: '2rem'
+    }}
+  >
+    <h1>404</h1>
+    <h5 style={{ marginBottom: '2rem' }}>This page could not be found.</h5>
+    <Button href={ROUTES.HOME} style={SitePrimaryButton}>
+      Back to home
+    </Button>
+  </div>
+);
+
+export default NotFound;

--- a/src/pages/Resume/Resume.tsx
+++ b/src/pages/Resume/Resume.tsx
@@ -38,6 +38,7 @@ const Resume: FC = () => {
             <Button
               href={GoogleDriveResumeLink}
               target="_blank"
+              rel="noopener noreferrer"
               style={SitePrimaryButton}
               onClick={() => {
                 TrackEvent(ANALYTICS_CONSTANTS.CLICK_RESUME);
@@ -51,6 +52,7 @@ const Resume: FC = () => {
             <Button
               href={GitHubLink}
               target="_blank"
+              rel="noopener noreferrer"
               style={SitePrimaryButton}
               onClick={() => {
                 TrackEvent(ANALYTICS_CONSTANTS.CLICK_GITHUB);
@@ -64,6 +66,7 @@ const Resume: FC = () => {
             <Button
               href={LinkedInLink}
               target="_blank"
+              rel="noopener noreferrer"
               style={SitePrimaryButton}
               onClick={() => {
                 TrackEvent(ANALYTICS_CONSTANTS.CLICK_LINKEDIN);
@@ -78,6 +81,7 @@ const Resume: FC = () => {
             <img
               style={{ width: '100%', borderRadius: '50%' }}
               src={ProfilePicture}
+              alt="Layne Britton"
             />
           </Col>
         </Row>
@@ -152,7 +156,11 @@ const Resume: FC = () => {
                   <>
                     <span>
                       An open-source mod for{' '}
-                      <a href="https://www.minecraft.net/en-us" target="_">
+                      <a
+                        href="https://www.minecraft.net/en-us"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
                         Minecraft
                       </a>{' '}
                       to chop down trees and mine ore in one swoop. Runs on all
@@ -180,7 +188,8 @@ const Resume: FC = () => {
                       protagonists. Winner of the{' '}
                       <a
                         href="https://www.college.columbia.edu/core/scholars/reflection/4135"
-                        target="_"
+                        target="_blank"
+                        rel="noopener noreferrer"
                       >
                         2020 Core Scholar award at Columbia University
                       </a>

--- a/src/util/Analytics.ts
+++ b/src/util/Analytics.ts
@@ -1,32 +1,25 @@
 import mixpanel from 'mixpanel-browser';
 
-let CURRENT_ENVIRONMENT: string;
-let ANALYTICS_TOKEN: string;
+const CURRENT_ENVIRONMENT = process.env.REACT_APP_ENVIRONMENT || '';
+const ANALYTICS_TOKEN = process.env.REACT_APP_MIXPANEL_ANALYTICS_TOKEN || '';
+
+let initialized = false;
+
+const IsProductionEnvironment = () => CURRENT_ENVIRONMENT === 'prod';
 
 export const InitializeAnalytics = () => {
-  CURRENT_ENVIRONMENT = process.env.REACT_APP_ENVIRONMENT || '';
-  ANALYTICS_TOKEN = process.env.REACT_APP_MIXPANEL_ANALYTICS_TOKEN || '';
-
-  if (!IsProductionEnvironment()) {
+  if (initialized || !IsProductionEnvironment() || !ANALYTICS_TOKEN) {
     return;
   }
 
-  if (ANALYTICS_TOKEN) {
-    mixpanel.init(ANALYTICS_TOKEN, { api_host: 'https://api.mixpanel.com' });
-  }
+  mixpanel.init(ANALYTICS_TOKEN, { api_host: 'https://api.mixpanel.com' });
+  initialized = true;
 };
 
 export const TrackEvent = (event: string) => {
-  if (!IsProductionEnvironment()) {
+  if (!initialized) {
     return;
   }
 
   mixpanel.track(event, { environment: CURRENT_ENVIRONMENT });
-};
-
-const IsProductionEnvironment = () => {
-  if (CURRENT_ENVIRONMENT === 'prod') {
-    return true;
-  }
-  return false;
 };


### PR DESCRIPTION
## Changes

Low effort changes thrown at ai tooling to try out new tools.

Flow:

- Github copilot ask mode -> Looking for high impact low effort changes
- GH copilot plan mode -> creating plan to implement selected ideas from that last with clear acceptance criteria
- Human review prompt plan, tweak to actual needs
- FInalized plan -> claude code for implementation
- Review changes -> make tweaks

### Metadata & SEO
- Fixed `manifest.json` `name`/`short_name` ("Infinite Dogs" → "Layne Britton — Software Engineer")
- Added Open Graph and Twitter card meta tags + improved description in `index.html`

### Analytics
- Refactored `Analytics.ts` to remove module-level mutable state and added an `initialized` guard so `TrackEvent` no-ops until init succeeds (prod + token only)
- Moved `InitializeAnalytics()` out of render into a `useEffect` in `App.tsx`
- Moved page-view `TrackEvent` calls into `useEffect` in `Home.tsx` and `Contact.tsx` (Contact's tracking was previously commented out — now active)

### Accessibility & security
- Added `rel="noopener noreferrer"` to all `target="_blank"` links in `Resume.tsx` and `ProjectCard.tsx`
- Fixed two invalid `target="_"` anchors to proper `target="_blank"` + rel
- Added `alt` attributes to the profile image and project card images
- Replaced invalid Bootstrap class `d-xs-block` with `d-block` in `ResponsiveContent.tsx`

### UI
- Replaced the bare 404 anchor with a styled `NotFound` page component

### Dependencies & docs
- Removed unused dependency `react-infinite-scroll-component`
- Updated `homepage` to HTTPS in `package.json`
- Updated readme

## Testing

```
 npm run test:e2e    

> layne-britton-net@0.1.0 test:e2e
> playwright test


Running 30 tests using 5 workers
  30 passed (24.5s)

To open last HTML report run:

  npx playwright show-report
```